### PR TITLE
Fix onStart for MotionPathActuator

### DIFF
--- a/src/motion/actuators/MotionPathActuator.hx
+++ b/src/motion/actuators/MotionPathActuator.hx
@@ -104,7 +104,9 @@ class MotionPathActuator<T> extends SimpleActuator<T, T> {
 			if (!initialized) {
 				
 				initialize ();
-				
+				trace("Init Motion path actuator");
+				start();
+
 			}
 			
 			if (!special) {

--- a/src/motion/actuators/MotionPathActuator.hx
+++ b/src/motion/actuators/MotionPathActuator.hx
@@ -104,7 +104,6 @@ class MotionPathActuator<T> extends SimpleActuator<T, T> {
 			if (!initialized) {
 				
 				initialize ();
-				trace("Init Motion path actuator");
 				start();
 
 			}


### PR DESCRIPTION
MotionPathActuator doesn't have call to start() on update. This commit adds it so we can use onStart on MotionPathActuator